### PR TITLE
Fix minor error in amcl.launch

### DIFF
--- a/diffbot_navigation/launch/amcl.launch
+++ b/diffbot_navigation/launch/amcl.launch
@@ -18,7 +18,7 @@
     <param name="min_particles"             value="500"/>
     <param name="max_particles"             value="5000"/>
     <param name="kld_err"                   value="0.02"/>
-    <param name="kld_err"                   value="0.99"/>
+    <param name="kld_z"                     value="0.99"/>
     <param name="update_min_d"              value="0.15"/>
     <param name="update_min_a"              value="0.15"/>
     <param name="resample_interval"         value="1"/>


### PR DESCRIPTION
The "kld_err" is initialized twice, and with the wrong values.
I guess you wanted to initialize the "kld_err" parameter to 0.01 and "kld_z" to 0.99.