### PR TITLE
Fix base_config PWM_MIN macro

### DIFF
--- a/diffbot_base/scripts/base_controller/lib/config/diffbot_base_config.h
+++ b/diffbot_base/scripts/base_controller/lib/config/diffbot_base_config.h
@@ -31,4 +31,4 @@
 
 
 #define PWM_MAX pow(2, PWM_BITS) - 1
-#define PWM_MIN -PWM_MAX
+#define PWM_MIN -(PWM_MAX)


### PR DESCRIPTION
Hi @fjp , Minor bug due to missed parenthesis.
The expected PWM_MIN value is -255, due to the missing parenthesis, the value becomes -257
`#define PWM_MIN -pow(2, PWM_BITS) -1`

After adding parenthesis:
`#define PWM_MIN -(pow(2, PWM_BITS) -1)`

Thx :)
